### PR TITLE
Add libsasl2-dev to installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ kafka_settings:
         sasl_mechanism: "sasl mechanism"
         sasl_username: "your sasl username"
         sasl_password: "your sasl password"
-# OR gql kafka producer
+# OR gql kafka producer if you want to get json messages
 #
 #kafka_settings:
 #  mode: gql

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ scan_type:
     # max_db_memory_usage: 3000000000
 
 kafka_settings:
-  mode: broxus
+  mode: broxus # it will try to write to 0..8 partition in topic, so, make sure that you have all set.
   raw_transaction_producer:
     topic: everscale-transactions
     brokers:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -42,7 +42,7 @@ echo 'INFO: Running native installation'
 
 echo 'INFO: installing and updating dependencies'
 sudo apt update && sudo apt upgrade
-sudo apt install build-essential llvm clang pkg-config libssl-dev
+sudo apt install build-essential llvm clang pkg-config libssl-dev libsasl2-dev
 
 echo 'INFO: installing Rust'
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
This package missed in default Ubuntu installation, so, nice to have it in installation script to make sure that it will work outside the proposed Docker installation 